### PR TITLE
Fixes to integrate map server into state estimator

### DIFF
--- a/maps_lcmtypes/CMakeLists.txt
+++ b/maps_lcmtypes/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.6.0)
 
 # pull in the pods macros. See cmake/pods.cmake for documentation
 set(POD_NAME maps)
+find_package(PkgConfig)
+pkg_check_modules(LCMTYPES_BOT2CORE lcmtypes_bot2-core)
+include_directories(${LCMTYPES_BOT2CORE_INCLUDE_DIRS})
+
 include(cmake/pods.cmake)
 
 include(cmake/lcmtypes.cmake)

--- a/plane-seg/CMakeLists.txt
+++ b/plane-seg/CMakeLists.txt
@@ -41,11 +41,11 @@ pods_install_pkg_config_file(${LIB_NAME}
     VERSION 0.0.1)
 
 # standalone lcm-based block fitter
-set(APP_NAME drc-block-fitter)
-add_executable(${APP_NAME} src/block-fitter.cpp)
-target_link_libraries(${APP_NAME} boost_system pthread)
-pods_use_pkg_config_packages(${APP_NAME} ${LIB_NAME} maps bot2-lcmgl-client)
-pods_install_executables(${APP_NAME})
+#set(APP_NAME drc-block-fitter)
+#add_executable(${APP_NAME} src/block-fitter.cpp)
+#target_link_libraries(${APP_NAME} boost_system pthread)
+#pods_use_pkg_config_packages(${APP_NAME} ${LIB_NAME} maps bot2-lcmgl-client)
+#pods_install_executables(${APP_NAME})
 
 
 # test program


### PR DESCRIPTION
Two fixes: 

1. some map lcmtypes depend on bot core lcmtypes. I have to tell where to look for them.
2. drc-block-fitter depends on drc messages. 

This PR is just to show you what I did to fix this.

I reccommend to create a branch.
